### PR TITLE
add TRACE_REDIS envvar gated stack inspection

### DIFF
--- a/redistools/conn.py
+++ b/redistools/conn.py
@@ -6,7 +6,10 @@ TRACE = os.getenv('TRACE_REDIS', 'false').lower() == "true"
 
 if TRACE:
     import inspect
-    logger_function = print
+    import logging
+    logger = logging.getLogger('redisutils')
+    logger.setLevel(logging.DEBUG)
+    logger_function = logger.debug
 
 SLAVEABLE_FUNCS = [
     "DBSIZE", "DEBUG", "GET", "GETBIT", "GETRANGE", "HGET", "HGETALL", "HKEYS",


### PR DESCRIPTION
Prints calling file, calling line, redis verb, and verb parameters.

This should allow us to look at ie) https://app.logdna.com/9a922e70a0/logs/view/d6110a27c4?q=label.env%3Ayellow%20label.stack%3Ahcaptcha and trivially enumerate who does what with Redis where and why.