### PR TITLE
calltrace polishing

### DIFF
--- a/redistools/conn.py
+++ b/redistools/conn.py
@@ -86,14 +86,14 @@ class Conn:
                     context = frame.code_context[0].strip()
                 else:
                     context = None
-                    machine_readable_stack_frame = dict(
-                        filename=frame.filename,
-                        lineno=frame.lineno,
-                        function=frame.function,
-                        redis_verb=name,
-                        args=args,
-                        kwargs=kwargs,
-                        context=context)
+                machine_readable_stack_frame = dict(
+                    filename=frame.filename,
+                    lineno=frame.lineno,
+                    function=frame.function,
+                    redis_verb=name,
+                    args=args,
+                    kwargs=kwargs,
+                    context=context)
                 logger_function(json.dumps(machine_readable_stack_frame))
             if name.upper() in SLAVEABLE_FUNCS:
                 return getattr(self.get_slave(), name)(*args, **kwargs)

--- a/redistools/conn.py
+++ b/redistools/conn.py
@@ -12,7 +12,6 @@ if TRACE:
     logger.setLevel(logging.DEBUG)
     logger_function = logger.debug
 
-
 SLAVEABLE_FUNCS = [
     "DBSIZE", "DEBUG", "GET", "GETBIT", "GETRANGE", "HGET", "HGETALL", "HKEYS",
     "HLEN", "HMGET", "HVALS", "INFO", "LASTSAVE", "LINDEX", "LLEN", "LRANGE",
@@ -87,10 +86,15 @@ class Conn:
                     context = frame.code_context[0].strip()
                 else:
                     context = None
-                    machine_readable_stack_frame = dict(filename=frame.filename, lineno=frame.lineno, function=frame.function, redis_verb=name, args=args, kwargs=kwargs, context=context)
-                logger_function(
-                    json.dumps(machine_readable_stack_frame)
-                )
+                    machine_readable_stack_frame = dict(
+                        filename=frame.filename,
+                        lineno=frame.lineno,
+                        function=frame.function,
+                        redis_verb=name,
+                        args=args,
+                        kwargs=kwargs,
+                        context=context)
+                logger_function(json.dumps(machine_readable_stack_frame))
             if name.upper() in SLAVEABLE_FUNCS:
                 return getattr(self.get_slave(), name)(*args, **kwargs)
             else:

--- a/redistools/conn.py
+++ b/redistools/conn.py
@@ -91,7 +91,7 @@ class Conn:
                     lineno=frame.lineno,
                     function=frame.function,
                     redis_verb=name,
-                    args=args,
+                    args=[a.decode() if isinstance(a, bytes) else a for a in args],
                     kwargs=kwargs,
                     context=context)
                 logger_function(json.dumps(machine_readable_stack_frame))

--- a/redistools/conn.py
+++ b/redistools/conn.py
@@ -9,8 +9,6 @@ if TRACE:
     import logging
     logger = logging.getLogger('redisutils')
     logger.setLevel(logging.DEBUG)
-    if not len(logger.handlers):
-        logger.addHandler(logging.StreamHandler())
     logger_function = logger.debug
 
 SLAVEABLE_FUNCS = [

--- a/redistools/conn.py
+++ b/redistools/conn.py
@@ -9,6 +9,8 @@ if TRACE:
     import logging
     logger = logging.getLogger('redisutils')
     logger.setLevel(logging.DEBUG)
+    if not len(logger.handlers):
+        logger.addHandler(logging.StreamHandler())
     logger_function = logger.debug
 
 SLAVEABLE_FUNCS = [
@@ -74,10 +76,13 @@ class Conn:
                 frame_index = 0
                 if len(stack) > 1:
                     frame_index += 1
-                frame = stack[stack_index]
-                while 'redistools' in stack[stack_index].filename:
-                    frame_index += 1
-                    frame = stack[stack_index]
+                frame = stack[frame_index]
+                while 'redistools' in stack[frame_index].filename:
+                    if frame_index < len(stack):
+                        frame_index += 1
+                        frame = stack[frame_index]
+                    else:
+                        break
                 if frame.code_context and len(frame.code_context):
                     context = frame.code_context[0].strip()
                 else:

--- a/redistools/conn.py
+++ b/redistools/conn.py
@@ -71,10 +71,13 @@ class Conn:
         def handlerFunc(*args, **kwargs):
             if TRACE:
                 stack = inspect.stack()
+                frame_index = 0
                 if len(stack) > 1:
-                    frame = stack[1]
-                else:
-                    frame = stack[-1]
+                    frame_index += 1
+                frame = stack[stack_index]
+                while 'redistools' in stack[stack_index].filename:
+                    frame_index += 1
+                    frame = stack[stack_index]
                 if frame.code_context and len(frame.code_context):
                     context = frame.code_context[0].strip()
                 else:

--- a/redistools/conn.py
+++ b/redistools/conn.py
@@ -7,9 +7,11 @@ TRACE = os.getenv('TRACE_REDIS', 'false').lower() == "true"
 if TRACE:
     import inspect
     import logging
+    import json
     logger = logging.getLogger('redisutils')
     logger.setLevel(logging.DEBUG)
     logger_function = logger.debug
+
 
 SLAVEABLE_FUNCS = [
     "DBSIZE", "DEBUG", "GET", "GETBIT", "GETRANGE", "HGET", "HGETALL", "HKEYS",
@@ -85,8 +87,9 @@ class Conn:
                     context = frame.code_context[0].strip()
                 else:
                     context = None
+                    machine_readable_stack_frame = dict(filename=frame.filename, lineno=frame.lineno, function=frame.function, redis_verb=name, args=args, kwargs=kwargs, context=context)
                 logger_function(
-                    f'{frame.filename}:{frame.lineno} in {frame.function} called "{name}" with {args}, {kwargs} via "{context}"'
+                    json.dumps(machine_readable_stack_frame)
                 )
             if name.upper() in SLAVEABLE_FUNCS:
                 return getattr(self.get_slave(), name)(*args, **kwargs)


### PR DESCRIPTION
JSON-serialize the inspected frame objects. Walk up the stack until not looking at redistools. Sanitize args from bytes as applicable.